### PR TITLE
Add movie metadata for start page (today & future movies)

### DIFF
--- a/src/data/future-movies.json
+++ b/src/data/future-movies.json
@@ -1,0 +1,122 @@
+[
+  {
+    "title": "Frostens Katedral",
+    "genre": "Fantasy",
+    "duration": 136,
+    "rating": 8.0,
+    "releaseDate": "2026-01-12",
+    "ageLimit": 11,
+    "tags": ["fantasy", "epic", "premiere"],
+    "language": "EN",
+    "description": "Lorem ipsum dolor sit amet. En uråldrig plats vaknar och kräver ett offer.",
+    "image": "frostens-katedral.jpg"
+  },
+  {
+    "title": "Sista Spårvagnen",
+    "genre": "Drama",
+    "duration": 107,
+    "rating": 7.3,
+    "releaseDate": "2026-02-03",
+    "ageLimit": 11,
+    "tags": ["drama", "stad", "svensk"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. En kvällstur blir början på en ny riktning i livet.",
+    "image": "sista-sparvagnen.jpg"
+  },
+  {
+    "title": "Rymdposten",
+    "genre": "Familj",
+    "duration": 92,
+    "rating": 7.5,
+    "releaseDate": "2026-02-21",
+    "ageLimit": 7,
+    "tags": ["family", "adventure", "animation"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. Ett litet paket på villovägar hamnar i galaxens mitt.",
+    "image": "rymdposten.jpg"
+  },
+  {
+    "title": "Bronsnatten",
+    "genre": "Thriller",
+    "duration": 115,
+    "rating": 7.7,
+    "releaseDate": "2026-03-08",
+    "ageLimit": 15,
+    "tags": ["thriller", "crime", "mystery"],
+    "language": "EN",
+    "description": "Lorem ipsum dolor sit amet. Ett fall som aldrig löstes – förrän nu.",
+    "image": "bronsnatten.jpg"
+  },
+  {
+    "title": "Ljudet av Tystnad",
+    "genre": "Drama",
+    "duration": 123,
+    "rating": 8.2,
+    "releaseDate": "2026-03-26",
+    "ageLimit": 11,
+    "tags": ["drama", "musik", "indie"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. När musiken försvinner måste du hitta en ny röst.",
+    "image": "ljudet-av-tystnad.jpg"
+  },
+  {
+    "title": "Operation Biosalong",
+    "genre": "Komedi",
+    "duration": 99,
+    "rating": 6.7,
+    "releaseDate": "2026-04-10",
+    "ageLimit": 7,
+    "tags": ["komedi", "bio", "ensemble"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. En misslyckad premiär blir årets roligaste kväll.",
+    "image": "operation-biosalong.jpg"
+  },
+  {
+    "title": "Järnvägens Barn",
+    "genre": "Äventyr",
+    "duration": 110,
+    "rating": 7.1,
+    "releaseDate": "2026-04-27",
+    "ageLimit": 7,
+    "tags": ["adventure", "family", "friendship"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. Två vänner följer spåren mot ett glömt löfte.",
+    "image": "jarnvagens-barn.jpg"
+  },
+  {
+    "title": "Kraschlandning i Kvarteret",
+    "genre": "Sci-Fi",
+    "duration": 128,
+    "rating": 7.6,
+    "releaseDate": "2026-05-19",
+    "ageLimit": 11,
+    "tags": ["sci-fi", "comedy", "aliens"],
+    "language": "EN",
+    "description": "Lorem ipsum dolor sit amet. När en farkost landar fel måste grannarna samarbeta.",
+    "image": "kraschlandning-kvarteret.jpg"
+  },
+  {
+    "title": "Skymningsarkivet",
+    "genre": "Mystery",
+    "duration": 103,
+    "rating": 7.0,
+    "releaseDate": "2026-06-02",
+    "ageLimit": 15,
+    "tags": ["mystery", "dark", "investigation"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. Dokument som inte borde finnas börjar dyka upp.",
+    "image": "skymningsarkivet.jpg"
+  },
+  {
+    "title": "Sommarens Sista Scen",
+    "genre": "Romantik",
+    "duration": 105,
+    "rating": 6.9,
+    "releaseDate": "2026-06-18",
+    "ageLimit": 7,
+    "tags": ["romantik", "feelgood", "summer"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. En sommarflirt får en andra chans – precis när allt tar slut.",
+    "image": "sommarens-sista-scen.jpg"
+  }
+]

--- a/src/data/today-movies.json
+++ b/src/data/today-movies.json
@@ -1,0 +1,122 @@
+[
+  {
+    "title": "Kallt Ljus",
+    "genre": "Drama",
+    "duration": 112,
+    "rating": 7.6,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 11,
+    "tags": ["svensk", "drama", "indie"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. En stillsam berättelse om mod och val.",
+    "image": "kallt-ljus.jpg"
+  },
+  {
+    "title": "Midnatt på Fyrisån",
+    "genre": "Mystery",
+    "duration": 104,
+    "rating": 7.2,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 15,
+    "tags": ["mystery", "thriller", "natt"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. Något händer i skuggorna – och ingen vill prata om det.",
+    "image": "midnatt-fyrisan.jpg"
+  },
+  {
+    "title": "Popcorn & Poesi",
+    "genre": "Romantik",
+    "duration": 96,
+    "rating": 6.9,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 7,
+    "tags": ["romantik", "feelgood", "bio"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. Två främlingar möts i en biosalong och allt förändras.",
+    "image": "popcorn-poesi.jpg"
+  },
+  {
+    "title": "Stål & Snö",
+    "genre": "Action",
+    "duration": 121,
+    "rating": 7.8,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 15,
+    "tags": ["action", "katastrof", "tempo"],
+    "language": "EN",
+    "description": "Lorem ipsum dolor sit amet. Ett race mot tiden när staden fryser till is.",
+    "image": "stal-sno.jpg"
+  },
+  {
+    "title": "Lilla Stjärnresan",
+    "genre": "Familj",
+    "duration": 88,
+    "rating": 7.1,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 7,
+    "tags": ["family", "animation", "jul"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. En varm film om vänskap, mod och en väldigt liten stjärna.",
+    "image": "lilla-stjarnresan.jpg"
+  },
+  {
+    "title": "Kodnamn: Eko",
+    "genre": "Thriller",
+    "duration": 109,
+    "rating": 7.4,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 15,
+    "tags": ["thriller", "spion", "teknik"],
+    "language": "EN",
+    "description": "Lorem ipsum dolor sit amet. Ett läckta meddelande startar en kedja av farliga beslut.",
+    "image": "kodnamn-eko.jpg"
+  },
+  {
+    "title": "Bistrons Hemlighet",
+    "genre": "Komedi",
+    "duration": 101,
+    "rating": 6.8,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 7,
+    "tags": ["komedi", "mat", "ensemble"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. När en kock försvinner måste alla spela med i en galen plan.",
+    "image": "bistrons-hemlighet.jpg"
+  },
+  {
+    "title": "Efter Regnet",
+    "genre": "Drama",
+    "duration": 118,
+    "rating": 8.1,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 11,
+    "tags": ["drama", "relationer", "stark"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. En historia om försoning och att börja om.",
+    "image": "efter-regnet.jpg"
+  },
+  {
+    "title": "Neonhjärtan",
+    "genre": "Sci-Fi",
+    "duration": 124,
+    "rating": 7.9,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 11,
+    "tags": ["sci-fi", "framtid", "cyber"],
+    "language": "EN",
+    "description": "Lorem ipsum dolor sit amet. En stad av ljus – och en hemlighet som kan släcka allt.",
+    "image": "neonhjartan.jpg"
+  },
+  {
+    "title": "Uppsala Udda",
+    "genre": "Dokumentär",
+    "duration": 90,
+    "rating": 7.0,
+    "releaseDate": "2025-12-24",
+    "ageLimit": 7,
+    "tags": ["dokumentar", "lokalt", "kultur"],
+    "language": "SV",
+    "description": "Lorem ipsum dolor sit amet. En charmig dokumentär om de små historierna i en stor stad.",
+    "image": "uppsala-udda.jpg"
+  }
+]

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,26 +2,32 @@ function setupRouting() {
   document.addEventListener("click", (e) => {
     const el = e.target.closest("[data-route]");
     if (!el) return;
+
     const route = el.dataset.route;
     if (!route) return;
+
     window.location.href = route;
   });
 }
+
 function setupContactForm() {
   const form = document.querySelector(".contact__form");
   if (!form) return;
+
   const successEl = form.querySelector(".contact__success");
+
   const setError = (fieldName, message) => {
     const errorEl = form.querySelector(`[data-error-for="${fieldName}"]`);
     if (errorEl) errorEl.textContent = message;
   };
+
   const clearErrors = () => {
     ["fullName", "email", "message"].forEach((name) => setError(name, ""));
     if (successEl) successEl.hidden = true;
   };
-  const isvalidEmail = (value) => {
-    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-  };
+
+  const isValidEmail = (value) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+
   form.addEventListener("submit", (e) => {
     e.preventDefault();
     clearErrors();
@@ -36,7 +42,7 @@ function setupContactForm() {
       setError("fullName", "Skriv in ditt namn igen, minst 2 tecken");
       ok = false;
     }
-    if (!isvalidEmail(email)) {
+    if (!isValidEmail(email)) {
       setError("email", "Ange en giltig epost-address");
       ok = false;
     }
@@ -44,11 +50,63 @@ function setupContactForm() {
       setError("message", "Meddelandet måste innehålla minst 10 tecken");
       ok = false;
     }
+
     if (!ok) return;
+
     if (successEl) successEl.hidden = false;
     form.reset();
   });
 }
 
-setupRouting();
-setupContactForm();
+async function loadMovies(jsonPath, containerSelector) {
+  try {
+    const response = await fetch(jsonPath);
+    if (!response.ok) throw new Error(`Kunde inte hämta: ${jsonPath}`);
+
+    const movies = await response.json();
+
+    const container = document.querySelector(containerSelector);
+    if (!container) {
+      console.warn(`Hittade ingen container för: ${containerSelector}`);
+      return;
+    }
+
+    container.innerHTML = "";
+
+    movies.forEach((movie) => {
+      const card = document.createElement("div");
+      card.classList.add("movie-card");
+
+      const tags = Array.isArray(movie.tags) ? movie.tags.join(", ") : "—";
+      const age = movie.ageLimit ?? "—";
+      const date = movie.releaseDate ?? "—";
+      const lang = movie.language ?? "—";
+      const desc = movie.description ?? "";
+
+      card.innerHTML = `
+        <h3>${movie.title}</h3>
+        <p><strong>Genre:</strong> ${movie.genre}</p>
+        <p><strong>Längd:</strong> ${movie.duration} min</p>
+        <p><strong>Betyg:</strong> ⭐ ${movie.rating}</p>
+        <p><strong>Ålder:</strong> ${age}</p>
+        <p><strong>Datum:</strong> ${date}</p>
+        <p><strong>Språk:</strong> ${lang}</p>
+        <p><strong>Taggar:</strong> ${tags}</p>
+        ${desc ? `<p><strong>Beskrivning:</strong> ${desc}</p>` : ""}
+      `;
+
+      container.appendChild(card);
+    });
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+// Kör när HTML är redo
+document.addEventListener("DOMContentLoaded", () => {
+  setupRouting();
+  setupContactForm();
+
+  loadMovies("/src/data/today-movies.json", "#today-movies");
+  loadMovies("/src/data/future-movies.json", "#future-movies");
+});


### PR DESCRIPTION
This PR adds extended movie metadata (age limit, release date, tags, language and description)
for today’s and upcoming movies.

The data structure is prepared for future sorting and filtering.
No UI filtering is implemented yet.