### PR TITLE
Added link to event-page on start-page

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
 
         <div class="main__welcome__item">
           <img class="main__welcome__img" src="src/pics/KINO-street.webp" alt="Kino utsikt från gatan">
-          <a href="#" class="btn btn--secondary" title="Evenemang hos oss">Evenemang hos oss</a>
+          <a href="eventPage.html" class="btn btn--secondary" title="Evenemang hos oss">Evenemang hos oss</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR has added a link in the startpage-welcome section button "Evenemang hos oss" so that when clicking it, you get redirected to the event-page.

Changes made:
-Added a href="eventPage.html in index.html under the "main__welcome__item" - Evenemang hos oss section

To test:
1) Open index.html in your web browser 
2) Go to the welcome section
3) Click the button "Evenemang hos oss" and see if you get redirected correctly.

NOTE: Make sure to write "npm run sass" in the terminal before looking at the layout. Without this it will not look as it should.