### PR TITLE
Feature/drop down menu 20

### DIFF
--- a/src/styles/_header.scss
+++ b/src/styles/_header.scss
@@ -35,26 +35,17 @@
 }
 
 .header__dropdown {
-      display: none;
-      position: absolute;
-      top: 100%;
-      left: 50%;
-      transform: translateX(-50%);
-      
-      background-color: var.$color-background-dark;
-      padding: 0.5rem 0;
-      border-radius: 0.25rem;
-      min-width: 12rem;
-    
-      list-style: none;
-      z-index: 1001;
-  }
-
-  .header__dropdown-item a {
-    display: block;
-    padding: 0.5rem 1rem;
-    white-space: nowrap;
-    text-decoration: none;
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%); 
+    background-color: var.$color-background-dark;
+    padding: 0.5rem 0;
+    border-radius: 0.25rem;
+    min-width: 12rem;
+    list-style: none;
+    z-index: 1001;
   }
 
   .header__menu-item:hover .header__dropdown,


### PR DESCRIPTION
This closes #20

The full menu at each breakpoint displays menu items' subitems in dropdown when hovering over menu items.

Requests related to styling of header at breakpoint beneath 768px  (logo not showing) have not been addressed in this pull request, as that is outside the scope of this issue and linked pull request (drop down menu at 768-900px and 900 and above) and previous issues with linked pull requests related to header styling. 

The reason styling beneath 768px was addressed in previous pull request was to show menu items for other contributors, whose reason for requesting this I presume is to test out their own stuff at smaller screens.